### PR TITLE
patched to handle serialization of undef required params.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 /nytprof*
 .*.sw[a-z]
 /MooseX-Storage-*
+.latest
+.ackrc

--- a/lib/MooseX/Storage/Engine.pm
+++ b/lib/MooseX/Storage/Engine.pm
@@ -49,6 +49,7 @@ sub expand_object {
     # mark the root object as seen ...
     $self->seen->{refaddr $data} = undef;
 
+
     $self->map_attributes('expand_attribute', $data, \%options);
     return $self->storage;
 }
@@ -58,14 +59,16 @@ sub expand_object {
 sub collapse_attribute {
     my ($self, $attr, $options)  = @_;
     my $value = $self->collapse_attribute_value($attr, $options);
-    return if !defined($value);
+    
+    return unless $attr->has_value($self->object);
     $self->storage->{$attr->name} = $value;
 }
 
 sub expand_attribute {
     my ($self, $attr, $data, $options)  = @_;
+    return unless exists $data->{$attr->name};
     my $value = $self->expand_attribute_value($attr, $data->{$attr->name}, $options);
-    $self->storage->{$attr->name} = defined $value ? $value : return;
+    $self->storage->{$attr->name} = $value;
 }
 
 sub collapse_attribute_value {

--- a/t/013_basic_json_required_undef.t
+++ b/t/013_basic_json_required_undef.t
@@ -1,0 +1,80 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Deep;
+
+use Test::Requires qw(
+    JSON::Any
+    Test::Deep::JSON
+);
+
+BEGIN {
+    plan tests => 11;
+    use_ok('MooseX::Storage');
+}
+
+{
+
+    package Foo;
+    use Moose;
+    use MooseX::Storage;
+
+    with Storage( 'format' => 'JSON' );
+
+    has 'number' => ( is => 'ro', isa => 'Int' );
+    has 'string' => ( is => 'ro', required => 1, isa => 'Str | Undef' );
+    has 'float'  => ( is => 'ro', isa => 'Num' );
+    has 'array'  => ( is => 'ro', isa => 'ArrayRef' );
+    has 'hash'   => ( is => 'ro', isa => 'HashRef' );
+    has 'object' => ( is => 'ro', isa => 'Object' );
+}
+
+{
+    my $foo = Foo->new(
+        number => 10,
+        string => undef,
+        float  => 10.5,
+        array  => [ 1 .. 10 ],
+        hash   => { map { $_ => undef } ( 1 .. 10 ) },
+        object => Foo->new( number => 2, string => "string" ),
+    );
+    isa_ok( $foo, 'Foo' );
+
+    my $json = $foo->freeze;
+
+    cmp_deeply(
+        $json,
+        json({
+            number => 10,
+            string => undef,
+            float => 10.5,
+            array => [ 1 .. 10 ],
+            hash => { map { $_ => undef } (1 .. 10) },
+            __CLASS__ => 'Foo',
+            object => {
+                number => 2,
+                string => "string",
+                __CLASS__ => 'Foo'
+            },
+        }),
+        'is valid JSON and content matches',
+    );
+}
+
+{
+    my $foo = Foo->new(
+        number => 10,
+        string => undef,
+        float  => 10.5,
+        array  => [ 1 .. 10 ],
+        hash   => { map { $_ => undef } ( 1 .. 10 ) },
+        object => Foo->new( number => 2, string => "string" ),
+    );
+    isa_ok( $foo, 'Foo' );
+
+    my $json = $foo->freeze;
+    
+    my $foo2 = Foo->thaw( $json );
+
+}


### PR DESCRIPTION
I had a model with the following attributes and I could not freeze and thaw it without an exception.

has 'string' => ( is => 'ro', required => 1, isa => 'Str | Undef' );

To reproduce you can run the attached test: t/013_basic_json_required_undef.t

The two changes I made are:
- When expanding I only set the attributes that exist in the data hash.
- When collapsing I set the value is the "has_value" attribute is set.

It passes all tests.
