### PR TITLE
Deep nested objects fix (RT Bug #81236)

### DIFF
--- a/lib/MooseX/Storage/Engine.pm
+++ b/lib/MooseX/Storage/Engine.pm
@@ -236,9 +236,17 @@ my %TYPES;
         expand => sub {
             my ( $array, @args ) = @_;
             foreach my $i (0 .. $#{$array}) {
-                next unless ref($array->[$i]) eq 'HASH'
-                         && exists $array->[$i]->{$CLASS_MARKER};
-                $array->[$i] = $OBJECT_HANDLERS{expand}->($array->[$i], @args);
+                if ( ref( $array->[$i] ) eq 'HASH' ) {
+                    if ( exists $array->[$i]->{$CLASS_MARKER} ) {
+                        $array->[$i] = $OBJECT_HANDLERS{expand}->( $array->[$i], @args );
+                    }
+                    else {
+                        $array->[$i] = $TYPES{HashRef}->{expand}->( $array->[$i], @args );
+                    }
+                }
+                elsif ( ref( $array->[$i] ) eq 'ARRAY' ) {
+                    $array->[$i] = $TYPES{ArrayRef}->{expand}->( $array->[$i], @args );
+                }
             }
             $array;
         },
@@ -262,9 +270,17 @@ my %TYPES;
         expand   => sub {
             my ( $hash, @args ) = @_;
             foreach my $k (keys %$hash) {
-                next unless ref($hash->{$k}) eq 'HASH'
-                         && exists $hash->{$k}->{$CLASS_MARKER};
-                $hash->{$k} = $OBJECT_HANDLERS{expand}->($hash->{$k}, @args);
+                if ( ref( $hash->{$k} ) eq 'HASH' ) {
+                    if ( exists $hash->{$k}->{$CLASS_MARKER} ) {
+                        $hash->{$k} = $OBJECT_HANDLERS{expand}->( $hash->{$k}, @args );
+                    }
+                    else {
+                        $hash->{$k} = $TYPES{HashRef}->{expand}->( $hash->{$k}, @args );
+                    }
+                }
+                elsif ( ref( $hash->{$k} ) eq 'ARRAY' ) {
+                    $hash->{$k} = $TYPES{ArrayRef}->{expand}->( $hash->{$k}, @args );
+                }
             }
             $hash;
         },

--- a/t/003_basic_w_embedded_objects.t
+++ b/t/003_basic_w_embedded_objects.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 49;
+use Test::More tests => 58;
 use Test::Deep;
 
 BEGIN {
@@ -162,8 +162,10 @@ ArrayRef and HashRef type handlers.
             map {
                 [
                     map {
-                        Foo->new( bars =>
-                                [ map { Bar->new( number => $_ ) } ( 1 .. 10 ) ]
+                        Foo->new(
+                            bars => [
+                                map { Bar->new( number => $_ ) } ( 1 .. 10 )
+                            ]
                             )
                     } ( 1 .. 10 )
                 ]
@@ -174,8 +176,10 @@ ArrayRef and HashRef type handlers.
             map {
                 {
                     map {
-                        $_ => Foo->new( bars =>
-                                [ map { Bar->new( number => $_ ) } ( 1 .. 10 ) ]
+                        $_ => Foo->new(
+                            bars => [
+                                map { Bar->new( number => $_ ) } ( 1 .. 10 )
+                            ]
                             )
                         } ( 1 .. 10 )
                 }
@@ -186,8 +190,10 @@ ArrayRef and HashRef type handlers.
             map {
                 $_ => [
                     map {
-                        Foo->new( bars =>
-                                [ map { Bar->new( number => $_ ) } ( 1 .. 10 ) ]
+                        Foo->new(
+                            bars => [
+                                map { Bar->new( number => $_ ) } ( 1 .. 10 )
+                            ]
                             )
                     } ( 1 .. 10 )
                     ]
@@ -198,8 +204,10 @@ ArrayRef and HashRef type handlers.
             map {
                 $_ => {
                     map {
-                        $_ => Foo->new( bars =>
-                                [ map { Bar->new( number => $_ ) } ( 1 .. 10 ) ]
+                        $_ => Foo->new(
+                            bars => [
+                                map { Bar->new( number => $_ ) } ( 1 .. 10 )
+                            ]
                             )
                     } ( 1 .. 10 )
                     }
@@ -443,4 +451,223 @@ ArrayRef and HashRef type handlers.
         },
         '... got the right frozen class'
     );
+}
+
+{
+    my $qux = Qux->unpack(
+        {
+            __CLASS__ => 'Qux',
+            foos_aa   => [
+                map {
+                    [
+                        map {
+                            {
+                                __CLASS__ => 'Foo',
+                                bars      => [
+                                    map {
+                                        {
+                                            __CLASS__ => 'Bar',
+                                            number    => $_,
+                                        }
+                                    } ( 1 .. 10 )
+                                ],
+                            }
+                        } ( 1 .. 10 )
+                    ]
+                } ( 1 .. 10 )
+            ],
+
+            foos_ah => [
+                map {
+                    {
+                        map {
+                            $_ => {
+                                __CLASS__ => 'Foo',
+                                bars      => [
+                                    map {
+                                        {
+                                            __CLASS__ => 'Bar',
+                                            number    => $_,
+                                        }
+                                    } ( 1 .. 10 )
+                                ],
+                                }
+                            } ( 1 .. 10 )
+                    }
+                } ( 1 .. 10 )
+            ],
+
+            foos_ha => {
+                map {
+                    $_ => [
+                        map {
+                            {
+                                __CLASS__ => 'Foo',
+                                bars      => [
+                                    map {
+                                        {
+                                            __CLASS__ => 'Bar',
+                                            number    => $_,
+                                        }
+                                    } ( 1 .. 10 )
+                                ],
+                            }
+                        } ( 1 .. 10 )
+                        ]
+                } ( 1 .. 10 )
+            },
+
+            foos_hh => {
+                map {
+                    $_ => {
+                        map {
+                            $_ => {
+                                __CLASS__ => 'Foo',
+                                bars      => [
+                                    map {
+                                        {
+                                            __CLASS__ => 'Bar',
+                                            number    => $_,
+                                        }
+                                    } ( 1 .. 10 )
+                                ],
+                                }
+                        } ( 1 .. 10 )
+                        }
+                } ( 1 .. 10 )
+            },
+
+            bazs_aa => [
+                map {
+                    [
+                        map {
+                            {
+                                __CLASS__ => 'Baz',
+                                bars      => {
+                                    map {
+                                        (
+                                            $_ => {
+                                                __CLASS__ => 'Bar',
+                                                number    => $_,
+                                            }
+                                            )
+                                    } ( 1 .. 10 )
+                                },
+                            }
+                        } ( 1 .. 10 )
+                    ]
+                } ( 1 .. 10 )
+            ],
+
+            bazs_ah => [
+                map {
+                    {
+                        map {
+                            $_ => {
+                                __CLASS__ => 'Baz',
+                                bars      => {
+                                    map {
+                                        (
+                                            $_ => {
+                                                __CLASS__ => 'Bar',
+                                                number    => $_,
+                                            }
+                                            )
+                                    } ( 1 .. 10 )
+                                },
+                                }
+                            } ( 1 .. 10 )
+                    }
+                } ( 1 .. 10 )
+            ],
+
+            bazs_ha => {
+                map {
+                    $_ => [
+                        map {
+                            {
+                                __CLASS__ => 'Baz',
+                                bars      => {
+                                    map {
+                                        (
+                                            $_ => {
+                                                __CLASS__ => 'Bar',
+                                                number    => $_,
+                                            }
+                                            )
+                                    } ( 1 .. 10 )
+                                },
+                            }
+                        } ( 1 .. 10 )
+                        ]
+                } ( 1 .. 10 )
+            },
+
+            bazs_hh => {
+                map {
+                    $_ => {
+                        map {
+                            $_ => {
+                                __CLASS__ => 'Baz',
+                                bars      => {
+                                    map {
+                                        (
+                                            $_ => {
+                                                __CLASS__ => 'Bar',
+                                                number    => $_,
+                                            }
+                                            )
+                                    } ( 1 .. 10 )
+                                },
+                                }
+                        } ( 1 .. 10 )
+                        }
+                } ( 1 .. 10 )
+            },
+        }
+    );
+    isa_ok( $qux, 'Qux' );
+
+
+    my $deep_check_isa;
+    $deep_check_isa = sub {
+        my ($what) = @_;
+
+        if ( ref $what eq 'HASH' ) {
+            subtest 'HASH' => sub {
+                foreach my $k ( keys %{$what} ) {
+                    $deep_check_isa->( $what->{$k} );
+                }
+            };
+        }
+        elsif ( ref $what eq 'ARRAY' ) {
+            subtest 'ARRAY' => sub {
+                foreach my $i ( 1 .. scalar @{$what} ) {
+                    $deep_check_isa->( $what->[ $i - 1 ] );
+                }
+            };
+        }
+        elsif ( ref $what eq 'Foo' ) {
+            foreach my $i ( 1 .. scalar @{ $what->bars } ) {
+                isa_ok( $what->bars->[ $i - 1 ], 'Bar' );
+                is( $what->bars->[ $i - 1 ]->number,
+                    $i, "... got the right number ($i) in the Bar" );
+            }
+        }
+        elsif ( ref $what eq 'Baz' ) {
+            foreach my $k ( keys %{ $what->bars } ) {
+                isa_ok( $what->bars->{$k}, 'Bar' );
+                is( $what->bars->{$k}->number,
+                    $k, "... got the right number ($k) in the Bar" );
+            }
+        }
+    };
+
+    for my $test (
+        'foos_aa', 'foos_ah', 'foos_ha', 'foos_hh',
+        'bazs_aa', 'bazs_ah', 'bazs_ha', 'bazs_hh',
+        )
+    {
+        subtest $test => sub { $deep_check_isa->( $qux->$test ) };
+    }
 }

--- a/t/003_basic_w_embedded_objects.t
+++ b/t/003_basic_w_embedded_objects.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 47;
+use Test::More tests => 49;
 use Test::Deep;
 
 BEGIN {
@@ -46,6 +46,22 @@ ArrayRef and HashRef type handlers.
         is  => 'ro',
         isa => 'HashRef'
     );
+
+    package Qux;
+    use Moose;
+    use MooseX::Storage;
+
+    with Storage;
+
+    has foos_aa => ( is => 'ro', isa => 'ArrayRef[ArrayRef[Foo]]' );
+    has foos_ah => ( is => 'ro', isa => 'ArrayRef[HashRef[Foo]]' );
+    has foos_ha => ( is => 'ro', isa => 'HashRef[ArrayRef[Foo]]' );
+    has foos_hh => ( is => 'ro', isa => 'HashRef[HashRef[Foo]]' );
+
+    has bazs_aa => ( is => 'ro', isa => 'ArrayRef[ArrayRef[Baz]]' );
+    has bazs_ah => ( is => 'ro', isa => 'ArrayRef[HashRef[Baz]]' );
+    has bazs_ha => ( is => 'ro', isa => 'HashRef[ArrayRef[Baz]]' );
+    has bazs_hh => ( is => 'ro', isa => 'HashRef[HashRef[Baz]]' );
 }
 
 {
@@ -137,4 +153,294 @@ ArrayRef and HashRef type handlers.
         isa_ok($baz->bars->{$k}, 'Bar');
         is($baz->bars->{$k}->number, $k, "... got the right number ($k) in the Bar in Baz");
     }
+}
+
+
+{
+    my $qux = Qux->new(
+        foos_aa => [
+            map {
+                [
+                    map {
+                        Foo->new( bars =>
+                                [ map { Bar->new( number => $_ ) } ( 1 .. 10 ) ]
+                            )
+                    } ( 1 .. 10 )
+                ]
+            } ( 1 .. 10 )
+        ],
+
+        foos_ah => [
+            map {
+                {
+                    map {
+                        $_ => Foo->new( bars =>
+                                [ map { Bar->new( number => $_ ) } ( 1 .. 10 ) ]
+                            )
+                        } ( 1 .. 10 )
+                }
+            } ( 1 .. 10 )
+        ],
+
+        foos_ha => {
+            map {
+                $_ => [
+                    map {
+                        Foo->new( bars =>
+                                [ map { Bar->new( number => $_ ) } ( 1 .. 10 ) ]
+                            )
+                    } ( 1 .. 10 )
+                    ]
+            } ( 1 .. 10 )
+        },
+
+        foos_hh => {
+            map {
+                $_ => {
+                    map {
+                        $_ => Foo->new( bars =>
+                                [ map { Bar->new( number => $_ ) } ( 1 .. 10 ) ]
+                            )
+                    } ( 1 .. 10 )
+                    }
+            } ( 1 .. 10 )
+        },
+
+        bazs_aa => [
+            map {
+                [
+                    map {
+                        Baz->new(
+                            bars => {
+                                map { ( $_ => Bar->new( number => $_ ) ) }
+                                    ( 1 .. 10 )
+                            }
+                            )
+                    } ( 1 .. 10 )
+                ]
+            } ( 1 .. 10 )
+        ],
+
+        bazs_ah => [
+            map {
+                {
+                    map {
+                        $_ => Baz->new(
+                            bars => {
+                                map { ( $_ => Bar->new( number => $_ ) ) }
+                                    ( 1 .. 10 )
+                            }
+                            )
+                        } ( 1 .. 10 )
+                }
+            } ( 1 .. 10 )
+        ],
+
+        bazs_ha => {
+            map {
+                $_ => [
+                    map {
+                        Baz->new(
+                            bars => {
+                                map { ( $_ => Bar->new( number => $_ ) ) }
+                                    ( 1 .. 10 )
+                            }
+                            )
+                    } ( 1 .. 10 )
+                    ]
+            } ( 1 .. 10 )
+        },
+
+        bazs_hh => {
+            map {
+                $_ => {
+                    map {
+                        $_ => Baz->new(
+                            bars => {
+                                map { ( $_ => Bar->new( number => $_ ) ) }
+                                    ( 1 .. 10 )
+                            }
+                            )
+                    } ( 1 .. 10 )
+                    }
+            } ( 1 .. 10 )
+        },
+
+    );
+    isa_ok( $qux, 'Qux' );
+
+    cmp_deeply(
+        $qux->pack,
+        {
+            __CLASS__ => 'Qux',
+            foos_aa   => [
+                map {
+                    [
+                        map {
+                            {
+                                __CLASS__ => 'Foo',
+                                bars      => [
+                                    map {
+                                        {
+                                            __CLASS__ => 'Bar',
+                                            number    => $_,
+                                        }
+                                    } ( 1 .. 10 )
+                                ],
+                            }
+                        } ( 1 .. 10 )
+                    ]
+                } ( 1 .. 10 )
+            ],
+
+            foos_ah => [
+                map {
+                    {
+                        map {
+                            $_ => {
+                                __CLASS__ => 'Foo',
+                                bars      => [
+                                    map {
+                                        {
+                                            __CLASS__ => 'Bar',
+                                            number    => $_,
+                                        }
+                                    } ( 1 .. 10 )
+                                ],
+                                }
+                            } ( 1 .. 10 )
+                    }
+                } ( 1 .. 10 )
+            ],
+
+            foos_ha => {
+                map {
+                    $_ => [
+                        map {
+                            {
+                                __CLASS__ => 'Foo',
+                                bars      => [
+                                    map {
+                                        {
+                                            __CLASS__ => 'Bar',
+                                            number    => $_,
+                                        }
+                                    } ( 1 .. 10 )
+                                ],
+                            }
+                        } ( 1 .. 10 )
+                        ]
+                } ( 1 .. 10 )
+            },
+
+            foos_hh => {
+                map {
+                    $_ => {
+                        map {
+                            $_ => {
+                                __CLASS__ => 'Foo',
+                                bars      => [
+                                    map {
+                                        {
+                                            __CLASS__ => 'Bar',
+                                            number    => $_,
+                                        }
+                                    } ( 1 .. 10 )
+                                ],
+                                }
+                        } ( 1 .. 10 )
+                        }
+                } ( 1 .. 10 )
+            },
+
+            bazs_aa => [
+                map {
+                    [
+                        map {
+                            {
+                                __CLASS__ => 'Baz',
+                                bars      => {
+                                    map {
+                                        (
+                                            $_ => {
+                                                __CLASS__ => 'Bar',
+                                                number    => $_,
+                                            }
+                                            )
+                                    } ( 1 .. 10 )
+                                },
+                            }
+                        } ( 1 .. 10 )
+                    ]
+                } ( 1 .. 10 )
+            ],
+
+            bazs_ah => [
+                map {
+                    {
+                        map {
+                            $_ => {
+                                __CLASS__ => 'Baz',
+                                bars      => {
+                                    map {
+                                        (
+                                            $_ => {
+                                                __CLASS__ => 'Bar',
+                                                number    => $_,
+                                            }
+                                            )
+                                    } ( 1 .. 10 )
+                                },
+                                }
+                            } ( 1 .. 10 )
+                    }
+                } ( 1 .. 10 )
+            ],
+
+            bazs_ha => {
+                map {
+                    $_ => [
+                        map {
+                            {
+                                __CLASS__ => 'Baz',
+                                bars      => {
+                                    map {
+                                        (
+                                            $_ => {
+                                                __CLASS__ => 'Bar',
+                                                number    => $_,
+                                            }
+                                            )
+                                    } ( 1 .. 10 )
+                                },
+                            }
+                        } ( 1 .. 10 )
+                        ]
+                } ( 1 .. 10 )
+            },
+
+            bazs_hh => {
+                map {
+                    $_ => {
+                        map {
+                            $_ => {
+                                __CLASS__ => 'Baz',
+                                bars      => {
+                                    map {
+                                        (
+                                            $_ => {
+                                                __CLASS__ => 'Bar',
+                                                number    => $_,
+                                            }
+                                            )
+                                    } ( 1 .. 10 )
+                                },
+                                }
+                        } ( 1 .. 10 )
+                        }
+                } ( 1 .. 10 )
+            },
+        },
+        '... got the right frozen class'
+    );
 }


### PR DESCRIPTION
Wrong packing/unpacking for nested objects

```perl
my $obj = StorableClass->new(
    h => {
         a => [ StorableClass->new(s => 'value'),
         ...
    ],
    ...
} );
my $hashref = $obj->pack;
```

Packs into:
```perl
{
    __CLASS__ => 'StorableClass',
    h => {
        a => [ bless({s => 'value'}, 'StorableClass') ]    # Blessed! XXX
    }
}
```
