### PR TITLE
(docs) fix usage of DateTime->new

### DIFF
--- a/lib/MooseX/Storage/Engine.pm
+++ b/lib/MooseX/Storage/Engine.pm
@@ -381,9 +381,13 @@ use case is adding new non-Moose classes to the type registry for
 serialization. Here is an example of this for DateTime objects. This
 assumes a C<DateTime> type has been registered.
 
+    use DateTime::Format::ISO8601;
+    
+    my $dt_parser = DateTime::Format::ISO8601->new();
+
     MooseX::Storage::Engine->add_custom_type_handler(
         'DateTime' => (
-            expand   => sub { DateTime->new(shift) },
+            expand   => sub { $dt_parser->parser_datetime(shift) },
             collapse => sub { (shift)->iso8601 },
         )
     );


### PR DESCRIPTION
DateTime->iso8601 returns a string, but DateTime->new( string ) throws an error:

     Odd number of parameters in call to DateTime::new

I've added a DateTime::Format parser to make this example work, but the extra dependency may be more confusing?

An alternative example (without the dependency) could be handling `Path::Class` (or `MooseX::Types::Path::Class`):

    MooseX::Storage::Engine->add_custom_type_handler( 
        'MooseX::Types::Path::Class::File' => (
          expand      => sub { Path::Class::File->new( shift ) },
          collapse    => sub { (shift)->stringify },
        )
    );

There might be some value in explicitly mentioning how to add handle `MooseX::Types::` anyway (I remember that being a gotcha when I first tried to use this module).