### PR TITLE
Add support for classes built at runtime

### DIFF
--- a/lib/MooseX/Storage/Base/SerializedClass.pm
+++ b/lib/MooseX/Storage/Base/SerializedClass.pm
@@ -1,0 +1,70 @@
+package MooseX::Storage::Base::SerializedClass;
+# ABSTRACT: Deserialize according to the serialized __CLASS__
+
+=head1 SYNOPSIS
+
+  package ThirdDimension;
+  use Moose::Role;
+
+  has 'z' => (is => 'rw', isa => 'Int');
+
+  package Point;
+  use Moose;
+  use MooseX::Storage;
+
+  with Storage( base => 'SerializedClass', traits => [ 'WithRoles' ] );
+
+  has 'x' => (is => 'rw', isa => 'Int');
+  has 'y' => (is => 'rw', isa => 'Int');
+
+  1;
+
+  use Moose::Util qw/ with_traits /;
+
+  my $p = with_traits( 'Point', 'ThirdDimension' )->new(x => 10, y => 10, z => 10);
+
+  my $packed = $p->pack(); 
+  # { __CLASS__ => 'Point', '__ROLES__' => [ 'ThirdDimension' ], x => 10, y => 10, z => 10 }
+
+  # unpack the hash into a class
+  my $p2 = Point->unpack($packed);
+
+  print $p2->z;
+
+=head1 DESCRIPTION
+
+Behaves like L<MooseX::Storage::Basic>, with the exception that 
+the unpacking will reinflate the object into the class and roles
+as provided in the serialized data. It is means to be used in
+conjuncture with L<MooseX::Storage::Traits::WithRoles>.
+
+=cut
+
+our $VERSION = '0.51';
+
+use Moose::Role;
+
+with 'MooseX::Storage::Basic';
+
+use Moose::Util qw/ with_traits /;
+use Class::Load 'load_class';
+
+use namespace::autoclean;
+
+around unpack => sub {
+    my( $orig, $class, $data, %args ) = @_;
+    $class = Class::Load::load_class( $data->{'__CLASS__'} );
+
+    if( my $roles = delete $data->{'__ROLES__'} ) {
+        $class = with_traits( $class, @$roles );
+        $data->{'__CLASS__'} = $class;
+    }
+
+    $orig->($class,$data,%args);
+};
+
+1;
+
+
+
+

--- a/lib/MooseX/Storage/Engine/Trait/WithRoles.pm
+++ b/lib/MooseX/Storage/Engine/Trait/WithRoles.pm
@@ -1,0 +1,54 @@
+package MooseX::Storage::Engine::Trait::WithRoles;
+# ABSTRACT: An engine trait to include roles in serialization
+
+our $VERSION = '0.51';
+
+use Moose::Util qw/ with_traits /;
+
+use Moose::Role;
+use namespace::autoclean;
+
+around collapse_object => sub {
+    my( $orig, $self, @args ) = @_;
+
+    my $packed = $orig->( $self, @args );
+
+    if( my @roles = map { $_->name } @{ $self->object->meta->roles } ) {
+        $packed->{'__ROLES__'} = \@roles;
+    }
+
+    if ( $self->object->meta->is_anon_class ) {
+        $packed->{'__CLASS__'} = ( $self->object->meta->superclasses )[0];
+    }
+
+    $packed;
+
+};
+
+around expand_object => sub {
+    my( $orig, $self, $data, @args ) = @_;
+
+    use Data::Printer;
+    p $data;
+$DB::single = 1;
+
+    if( my $roles = delete $data->{'__ROLES__'} ) {
+        my $class_with_roles = with_traits(
+            $data->{'__CLASS__'},
+            @$roles,
+        );
+        $data->{'__CLASS__'} = $class_with_roles;
+        warn $class_with_roles;
+        $self->class($class_with_roles);
+    }
+
+    use Data::Printer;
+    p $data;
+
+    $orig->($self,$data,@args);
+};
+
+1;
+
+__END__
+

--- a/lib/MooseX/Storage/Traits/WithRoles.pm
+++ b/lib/MooseX/Storage/Traits/WithRoles.pm
@@ -1,0 +1,74 @@
+package MooseX::Storage::Traits::WithRoles;
+# ABSTRACT: A custom trait to include roles in serialization
+
+our $VERSION = '0.51';
+
+use Moose::Role;
+use namespace::autoclean;
+
+requires 'pack';
+requires 'unpack';
+
+around 'pack' => sub {
+    my ($orig, $self, %args) = @_;
+    $args{engine_traits} ||= [];
+    push(@{$args{engine_traits}}, 'WithRoles');
+    $self->$orig(%args);
+};
+
+around 'unpack' => sub {
+    my ($orig, $self, $data, %args) = @_;
+    $args{engine_traits} ||= [];
+    push(@{$args{engine_traits}}, 'WithRoles');
+    $self->$orig($data, %args);
+};
+
+no Moose::Role;
+
+1;
+
+__END__
+
+=head1 SYNOPSIS
+
+  package ThirdDimension;
+  use Moose::Role;
+
+  has 'z' => (is => 'rw', isa => 'Int');
+
+  package Point;
+  use Moose;
+  use MooseX::Storage;
+
+  with Storage( base => 'SerializedClass', traits => [ 'WithRoles' ] );
+
+  has 'x' => (is => 'rw', isa => 'Int');
+  has 'y' => (is => 'rw', isa => 'Int');
+
+  1;
+
+  use Moose::Util qw/ with_traits /;
+
+  my $p = with_traits( 'Point', 'ThirdDimension' )->new(x => 10, y => 10, z => 10);
+
+  my $packed = $p->pack(); 
+  # { __CLASS__ => 'Point', '__ROLES__' => [ 'ThirdDimension' ], x => 10, y => 10, z => 10 }
+
+  # unpack the hash into a class
+  my $p2 = Point->unpack($packed);
+
+  print $p2->z;
+
+=head1 DESCRIPTION
+
+This trait is meant to be used when a base class will be consuming roles at runtime
+via (for example) C<with_traits>.
+Without this trait, the '__CLASS__' attribute of the serialized object would be the name
+of the resulting anonymous class, which is useless to reconstruct the class after the fact.
+
+When this trait is used, the serialized C<__CLASS__> value will be the base 
+class, and C<__ROLES__> will contain the list of roles that it consumes. If used
+in conjecture with L<MooseX::Storage::Base::SerializedClass>, C<unpack()> will reinflate the data
+in the right class augmented by the given roles.
+
+=cut

--- a/t/pack-roles.t
+++ b/t/pack-roles.t
@@ -1,0 +1,48 @@
+#!/usr/bin/perl 
+
+use strict;
+use warnings;
+
+use Test::More tests => 1;
+
+use Moose::Util qw' with_traits';
+
+{
+    package Bar;
+    use Moose::Role;
+    has y => ( is => 'ro', default => 2 );
+}
+
+{
+    package Foo;
+    use Moose;
+    use MooseX::Storage;
+
+    with Storage( base => 'SerializedClass', traits => [ 'WithRoles' ] );
+
+    has x => (
+        is => 'ro',
+        default => 3,
+    );
+
+}
+
+my $x = with_traits( 'Foo', 'Bar' )->new;
+
+my $packed = $x->pack;
+
+is_deeply $packed => {
+    '__CLASS__' => 'Foo',
+    '__ROLES__' => [ qw/ Bar / ],
+    x => 3,
+    y => 2,
+}, 'packed';
+
+my $y = Foo->unpack($packed);
+
+is $y->x => 3;
+is $y->y => 2;
+
+
+
+


### PR DESCRIPTION
I'm adding a new trait to deal with the re-inflating of classes that are composed at runtime. 

It won't deal with parameterized roles, but I think we can deal with that. :-)