### PR TITLE
fix for MooseX::Types maybe types not serializing

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for MooseX-Storage
 
 {{$NEXT}}
+  - support serialization of "maybe" types created by MooseX::Types (PR#12)
 
 0.50      2015-05-05 20:09:42Z
   - revert changes in 0.49 for deeply-nested objects (see RT#104106)

--- a/dist.ini
+++ b/dist.ini
@@ -41,6 +41,8 @@ conflicts_module = Moose::Conflicts
 [Prereqs::Soften]
 :version = 0.004000
 module = Digest::HMAC_SHA1
+module = MooseX::Types
+module = MooseX::Types::Moose
 modules_from_features = 1
 to_relationship = suggests
 copy_to         = develop.requires

--- a/t/400_moosex_types.t
+++ b/t/400_moosex_types.t
@@ -1,0 +1,62 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Deep;
+
+# blech! but Test::Requires does a stringy eval, so this works...
+use Test::Requires { 'MooseX::Types' => '()' };
+
+{
+    package MyTypes;
+    use strict;
+    use warnings;
+    use MooseX::Types -declare => [ qw(MyNum MaybeMyNum) ];
+    use MooseX::Types::Moose 'Num';
+    subtype MyNum, as Num;
+    subtype MaybeMyNum, as maybe_type(MyNum);
+}
+
+{
+    package MyClass;
+    use Moose;
+    use MooseX::Storage;
+
+    with Storage;
+
+    has 'mynum'  => ( is => 'ro', isa => MyTypes::MyNum );
+    has 'maybe_mynum'  => ( is => 'ro', isa => MyTypes::MaybeMyNum );
+}
+
+my $obj = MyClass->new(
+    mynum => 10,
+    maybe_mynum => 20,
+);
+
+my $packed = $obj->pack;
+
+cmp_deeply(
+    $packed,
+    {
+        __CLASS__ => 'MyClass',
+        mynum => 10,
+        maybe_mynum => 20,
+    },
+    'correctly serialized a MooseX::Type attribute using Maybe',
+);
+
+my $unpacked = MyClass->unpack($packed);
+
+cmp_deeply(
+    $unpacked,
+    all(
+        isa('MyClass'),
+        noclass({
+            mynum => 10,
+            maybe_mynum => 20,
+        }),
+    ),
+    'correctly deserialized data from a MooseX::Type attribute using Maybe',
+);
+
+done_testing;


### PR DESCRIPTION
Maybe types coming from MXT are wrapped in another layer of ::Parameterized,
so we need to dig deeper to figure out the core type.


(for review only -- there are unrelated fixes that need to be made to the distribution before a release can be made.)