### PR TITLE
remember decision in find_type_handler

### DIFF
--- a/lib/MooseX/Storage/Engine.pm
+++ b/lib/MooseX/Storage/Engine.pm
@@ -327,8 +327,10 @@ sub find_type_handler {
     my %seen;
     my @fallback = grep { !$seen{$_}++ } qw/Int Num Str Value/, keys %TYPES;
     foreach my $type ( @fallback ) {
-        return $TYPES{$type}
-            if $type_constraint->is_subtype_of($type);
+        if ($type_constraint->is_subtype_of($type)) {
+            $TYPES{$type_constraint->name} = $TYPES{$type};
+            return $TYPES{$type};
+        }
     }
 
     # NOTE: the reason the above will work has to do with the fact that custom


### PR DESCRIPTION
I am thawing a 8MB json file with roundabout 50k Moose objects with some custom types in it.
This patch reduces the runtime from 23 sec to 13 sec on my box.