### PR TITLE
suggest JSONpm rather than recommend

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -60,7 +60,7 @@ JSON::MaybeXS = 1.001000
 
 [OptionalFeature / JSON-RuntimeRecommends]
 -description = Serialize to JSON. You should have at least one serialization format.
--always_recommend = 1
+-always_suggest = 1
 -default = 1
 MooseX::Storage::Format::JSONpm = 0
 


### PR DESCRIPTION
MooseX::Storage::Format::JSONpm is not needed by most people, so it can
be left as a suggested prereq.  This also avoids a circular dependency
for people including recommends.